### PR TITLE
Analog Sensor CAN Format Change

### DIFF
--- a/VehicleCode/Input/AnalogSensor.cpp
+++ b/VehicleCode/Input/AnalogSensor.cpp
@@ -12,18 +12,16 @@
  * Initializes an AnalogSensor object with specified parameters.
  *
  * @param id (int) The unique identifier for the sensor.
- * @param freq (int) The update delay of the sensor in milliseconds.
+ * @param waitTime (int) The update delay of the sensor in milliseconds.
  * @param inPins (int) The input pin id for the analog sensor.
  */
-AnalogSensor::AnalogSensor(int id, int waitTime, int inPin, int bias, int max, int dataLength) {
+AnalogSensor::AnalogSensor(int id, int waitTime, int inPin) {
     sensorID = id;
     this->waitTime = waitTime;
     previousUpdateTime = millis();
     inputPins[0] = inPin;
     sensorValue = 0;
-    this->bias = bias;
-    this->max = max;
-    this->dataLength = dataLength;
+    this->dataLength = 2;
 };
 
 /**
@@ -37,7 +35,7 @@ int AnalogSensor::readInputs() {
     previousUpdateTime = millis();
 
     //Grab Sensor Value
-    sensorValue = rescale(analogRead(inputPins[0]));
+    sensorValue = analogRead(inputPins[0]);
 
     //Return a pointer to the private value
     return sensorValue;
@@ -48,13 +46,21 @@ int AnalogSensor::readInputs() {
 /**
  * @brief Builds the data array for the CAN message.
  * 
- * @param torque (int) The torque value to be sent.
- * @param percent (int) The percent value to be sent.
+ * @param value value that was read from the sensor allows for it to be converted to CAN format
  * 
  * @return (int*) The data array for the CAN message.
 */
 int* AnalogSensor::buildData(int value) {
-    return new int[1]{value};
+
+    int first = value / 100;
+    int second;
+
+    second = value - (first * 100);
+
+
+
+
+    return new int[2]{first, second};
 }
 
 /**

--- a/VehicleCode/Input/AnalogSensor.cpp
+++ b/VehicleCode/Input/AnalogSensor.cpp
@@ -38,7 +38,7 @@ int AnalogSensor::readInputs() {
     sensorValue = analogRead(inputPins[0]);
 
     //Returns sensorValue but limits it to 1023
-    return (sensorValue < 1023) ? : 1023;
+    return (sensorValue < 1023) ? sensorValue : 1023;
     
 };
 

--- a/VehicleCode/Input/AnalogSensor.cpp
+++ b/VehicleCode/Input/AnalogSensor.cpp
@@ -37,30 +37,24 @@ int AnalogSensor::readInputs() {
     //Grab Sensor Value
     sensorValue = analogRead(inputPins[0]);
 
-    //Return a pointer to the private value
-    return sensorValue;
+    //Returns sensorValue but limits it to 1023
+    return (sensorValue < 1023) ? : 1023;
     
 };
 
 
 /**
- * @brief Builds the data array for the CAN message.
+ * @brief Builds the data array for the CAN message. Expected input is the analog sensor raw value that is read
+ * Expected output is a 2 item array that contains [1000s place 100s place, 10s place 1s place]
+ * EX: 1023 -> [10, 23] and 921 -> [9, 21] 
  * 
- * @param value value that was read from the sensor allows for it to be converted to CAN format
+ * @param int value value that was read from the sensor allows for it to be converted to CAN format
  * 
  * @return (int*) The data array for the CAN message.
 */
 int* AnalogSensor::buildData(int value) {
 
-    int first = value / 100;
-    int second;
-
-    second = value - (first * 100);
-
-
-
-
-    return new int[2]{first, second};
+    return new int[2]{(value / 100), (value - ((value / 100) * 100))};
 }
 
 /**

--- a/VehicleCode/Input/AnalogSensor.h
+++ b/VehicleCode/Input/AnalogSensor.h
@@ -7,7 +7,9 @@
 class AnalogSensor : public Sensor {
 private:
     // Additional attributes specific to AnalogSensor
-    // Currently None are needed
+    int sensorValue = 0;
+    // int bias = 0;
+    // int max = 1023;
 
 public:
     // Constructor

--- a/VehicleCode/Input/AnalogSensor.h
+++ b/VehicleCode/Input/AnalogSensor.h
@@ -3,16 +3,15 @@
 
 #include "Sensor.h"
 #include <Arduino.h>
+
 class AnalogSensor : public Sensor {
 private:
     // Additional attributes specific to AnalogSensor
-    int sensorValue = 0;
-    int bias = 0;
-    int max = 1023;
+    // Currently None are needed
 
 public:
     // Constructor
-    AnalogSensor(int id, int waitTime, int inPin, int bias, int max, int dataLength); 
+    AnalogSensor(int id, int waitTime, int inPin); 
 
     // Implement the pure virtual functions from the base class
     int readInputs() override;

--- a/VehicleCode/TestingAndCalibration/SensorTesting/include/AnalogSensor.h
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/include/AnalogSensor.h
@@ -13,7 +13,7 @@ private:
 
 public:
     // Constructor
-    AnalogSensor(int id, int waitTime, int inPin, int bias, int max, int dataLength); 
+    AnalogSensor(int id, int waitTime, int inPin); 
 
     // Implement the pure virtual functions from the base class
     int readInputs() override;

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/AnalogSensor.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/AnalogSensor.cpp
@@ -15,15 +15,15 @@
  * @param freq (int) The update delay of the sensor in milliseconds.
  * @param inPins (int) The input pin id for the analog sensor.
  */
-AnalogSensor::AnalogSensor(int id, int waitTime, int inPin, int bias, int max, int dataLength) {
+AnalogSensor::AnalogSensor(int id, int waitTime, int inPin) {
     sensorID = id;
     this->waitTime = waitTime;
     previousUpdateTime = millis();
     inputPins[0] = inPin;
     sensorValue = 0;
-    this->bias = bias;
-    this->max = max;
-    this->dataLength = dataLength;
+    // this->bias = bias;
+    // this->max = max;
+    this->dataLength = 2;
 };
 
 /**
@@ -37,7 +37,7 @@ int AnalogSensor::readInputs() {
     previousUpdateTime = millis();
 
     //Grab Sensor Value
-    sensorValue = rescale(analogRead(inputPins[0]));
+    sensorValue = analogRead(inputPins[0]);
 
     //Return a pointer to the private value
     return sensorValue;
@@ -54,7 +54,16 @@ int AnalogSensor::readInputs() {
  * @return (int*) The data array for the CAN message.
 */
 int* AnalogSensor::buildData(int value) {
-    return new int[1]{value};
+
+    int first = value / 100;
+    int second;
+
+    second = value - (first * 100);
+
+
+
+
+    return new int[2]{first, second};
 }
 
 /**

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/AnalogSensor.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/AnalogSensor.cpp
@@ -21,8 +21,6 @@ AnalogSensor::AnalogSensor(int id, int waitTime, int inPin) {
     previousUpdateTime = millis();
     inputPins[0] = inPin;
     sensorValue = 0;
-    // this->bias = bias;
-    // this->max = max;
     this->dataLength = 2;
 };
 

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/DataCollector.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/DataCollector.cpp
@@ -58,7 +58,6 @@ void DataCollector::checkSensors() {
 void DataCollector::readData(Sensor* sensor) {
     // Call the readInputs method to obtain an array of ints
     rawData = sensor->readInputs();
-    Serial.println(rawData);
     
     if (rawData != -1) {
         sendData = sensor->buildData(rawData);
@@ -68,6 +67,14 @@ void DataCollector::readData(Sensor* sensor) {
         sendData = sensor->buildError();
         sendID = ERROR_ID;
         sendLength = ERROR_LENGTH;
+    }
+
+    if(sensor->getId() != 0) { // PRINTS THE DATA TO MONITOR WHAT IS BEING SENT
+        Serial.print(sensor->getId());
+        Serial.print(": [1] = ");
+        Serial.print(sendData[0]);
+        Serial.print(" [2] = ");
+        Serial.println(sendData[1]);
     }
 
     // Create a new sensor data object for each int in the array

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/ThrottleSensor.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/ThrottleSensor.cpp
@@ -61,15 +61,15 @@ int ThrottleSensor::readInputs() {
     //Grab Sensor Value
     throttle1 = map(analogRead(inputPins[1]), 0, 175, MIN_OUTPUT, MAX_OUTPUT);
     throttle2 = map(-analogRead(inputPins[0]), -max, -810, MIN_OUTPUT, MAX_OUTPUT);
-    Serial.print("RAW");
-    Serial.println(analogRead(inputPins[1]));
+    // Serial.print("RAW");
+    // Serial.println(analogRead(inputPins[1]));
     // throttle1 = rescale(analogRead(inputPins[0]));          // calls map function
     // throttle2 = rescale(-analogRead(inputPins[1]), true);   // calls inverted map function
 
-    Serial.print("T1: ");
-    Serial.print(throttle1);
-    Serial.print(" T2: ");
-    Serial.println(throttle2);
+    // Serial.print("T1: ");
+    // Serial.print(throttle1);
+    // Serial.print(" T2: ");
+    // Serial.println(throttle2);
 
     //Return a pointer to the private value
     if (checkError(throttle1, throttle2)) {
@@ -97,8 +97,8 @@ int ThrottleSensor::readInputs() {
 */
 bool ThrottleSensor::checkError(int percent1, int percent2) {
 
-    Serial.print("abs: ");
-    Serial.println(abs(percent1 - percent2));
+    // Serial.print("abs: ");
+    // Serial.println(abs(percent1 - percent2));
     
     // update countMismatch
     if (abs(percent1 - percent2) < ERROR_TOL) {
@@ -129,8 +129,8 @@ int* ThrottleSensor::buildData(int torque){
         torque = 0;
     }
 
-    Serial.print("SENT TORQUE: ");
-    Serial.println(torque);
+    // Serial.print("SENT TORQUE: ");
+    // Serial.println(torque);
 
     // convert to motor controller format
     sendData[0] = getLow(torque); //torqueLow

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/ThrottleSensor.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/ThrottleSensor.cpp
@@ -61,15 +61,8 @@ int ThrottleSensor::readInputs() {
     //Grab Sensor Value
     throttle1 = map(analogRead(inputPins[1]), 0, 175, MIN_OUTPUT, MAX_OUTPUT);
     throttle2 = map(-analogRead(inputPins[0]), -max, -810, MIN_OUTPUT, MAX_OUTPUT);
-    // Serial.print("RAW");
-    // Serial.println(analogRead(inputPins[1]));
-    // throttle1 = rescale(analogRead(inputPins[0]));          // calls map function
-    // throttle2 = rescale(-analogRead(inputPins[1]), true);   // calls inverted map function
 
-    // Serial.print("T1: ");
-    // Serial.print(throttle1);
-    // Serial.print(" T2: ");
-    // Serial.println(throttle2);
+    //Insert Debug Print statements here if sensors disagree
 
     //Return a pointer to the private value
     if (checkError(throttle1, throttle2)) {
@@ -125,7 +118,7 @@ int* ThrottleSensor::buildData(int torque){
 
     
 
-    if(torque <= 90) {
+    if(torque <= 90) { // Buffer for the 
         torque = 0;
     }
 

--- a/VehicleCode/TestingAndCalibration/SensorTesting/src/main.cpp
+++ b/VehicleCode/TestingAndCalibration/SensorTesting/src/main.cpp
@@ -55,11 +55,14 @@ const int torque = 200;
 int countMismatch = 0;
 
 // initialize throttle sensor
-int throttleFreq = 1;
-int numSensors = 1;
+int throttleFreq = 30;
+int numSensors = 2;
+int damperID = 12;
+int damperFreq = 75;
+int damperPin = 17;
 ThrottleSensor throttle = ThrottleSensor(THROTTLE_POT, throttleFreq, POT1, POT2, BIAS1, MAX1, LENGTH);
-AnalogSensor tireSpeed1 = AnalogSensor(WHEEL_SPEED_FL, 1, 26, 0, 100, 1);
-Sensor* sensors[] = {&throttle};
+AnalogSensor damperPot1 = AnalogSensor(damperID, damperFreq, damperPin);
+Sensor* sensors[] = {&throttle, &damperPot1};
 DataCollector collector = DataCollector(sensors, numSensors, millis());
 
 
@@ -83,6 +86,5 @@ void setup() {
 void loop() {
 
   collector.checkSensors();
- 
-  delay(DELAYBY);
+
 }


### PR DESCRIPTION
Changes the format that an Analog Sensor Sends data over the Can line intending to preserve data resolution and standardization.